### PR TITLE
Display user titles in forum posts

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -72,9 +72,15 @@ userController.getUserDataByUID = async function (callerUid, uid) {
 	}
 
 	userData = await user.hidePrivateData(userData, callerUid);
+	userData.title = userData.groupTitleArray ? userData.groupTitleArray[0] : ''; // Assign first group title if available
+
+	// Fetch and include user title
+	const title = await user.getUserField(uid, 'title');
+	userData.title = title || '';  // Ensure a default empty string if no title exists
 
 	return userData;
 };
+
 
 require('../promisify')(userController, [
 	'getCurrentUser', 'getUserByUID', 'getUserByUsername', 'getUserByEmail',

--- a/src/views/partials/topic/post-preview.tpl
+++ b/src/views/partials/topic/post-preview.tpl
@@ -4,6 +4,10 @@
             <a href="{{{ if post.user.userslug }}}{config.relative_path}/user/{post.user.userslug}{{{ else }}}#{{{ end }}}">
                 {buildAvatar(post.user, "24px", true, "", "user/picture")} {post.user.username}
             </a>
+            {{{ if post.user.title }}}
+            <p class="user-title">{post.user.title}</p>
+            {{{ end }}}
+
             <span class="timeago text-xs" title="{post.timestampISO}"></span>
         </div>
         <div class="content">{post.content}</div>


### PR DESCRIPTION
This PR modifies the post template to display user titles under their usernames in posts. 
If a user has a title (e.g., "Student", "TA"), it is now shown below their name.
